### PR TITLE
Ready for Prime Time

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "grunt-coffeecov",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Grunt task to compile CoffeeScript to Javascript Coverage",
   "main": "Gruntfile.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "grunt-coffeecov",
-  "version": "0.1.1",
+  "version": "0.1.5",
   "description": "Grunt task to compile CoffeeScript to Javascript Coverage",
   "main": "Gruntfile.js",
   "scripts": {

--- a/tasks/coffeecov.js
+++ b/tasks/coffeecov.js
@@ -29,6 +29,9 @@ module.exports = function(grunt) {
         stream.on('end', function() {
           done();
         });
+        stream.on('close', function() {
+          done();
+        });
 
         options.initFileStream = stream;
       }
@@ -37,7 +40,7 @@ module.exports = function(grunt) {
 
       if(options.initFileStream) {
         options.initFileStream.end();
-      } else {
+      } else {        
         done();
       }
 


### PR DESCRIPTION
* Removes 2 unneeded ESLint peer dependencies
* Specifies "ISC" license (simplified "BSD"), eliminating NPM installation warning
* Version is now "1.0.0"